### PR TITLE
Fix word size used by address offset template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(tactyk-p C CXX)
-project(tactyk-p VERSION 0.8.1)
+project(tactyk-p VERSION 0.8.2)
 
 add_library(tactyk
   libtactyk/tactyk.c

--- a/devlog
+++ b/devlog
@@ -1,3 +1,6 @@
+8 Jun 2023 [fix-0.8.2]
+Fix word size used by address offset template
+
 5 Jun 2023 [0.8.1]
 tactyk-emit now produces detailed error reports when instruction interpretation fails.
 The most common errors are expected to be unrecognized operands, unrecognized instructions, and missing templates, which should be fairly easy to recognize.

--- a/rsc/tactyk_core_memory.visa
+++ b/rsc/tactyk_core_memory.visa
@@ -444,9 +444,9 @@ instruction push
 extend instruction assign select-template
   case OD
     code
-      cmp $B, fs:[$CTX_ADDRESS_BOUND + random_const_FS]
+      cmp %[$B]_32, dword fs:[$CTX_ADDRESS_BOUND + random_const_FS]
       errorge STATUS_ROGUE_POINTER
-      cmp $B, 0
+      cmp %[$B]_32, 0
       errorlt STATUS_ROGUE_POINTER
       lfence
       mov $ADDRESS_REGISTER, $B
@@ -455,9 +455,9 @@ extend instruction assign select-template
   case OI OC
     code
       $LD_B_IMMEDIATE
-      cmp rTEMPA, fs:[$CTX_ADDRESS_BOUND + random_const_FS]
+      cmp rTEMPA_32, dword fs:[$CTX_ADDRESS_BOUND + random_const_FS]
       errorge STATUS_ROGUE_POINTER
-      cmp rTEMPA, 0
+      cmp rTEMPA_32, 0
       errorlt STATUS_ROGUE_POINTER
       lfence
       mov $ADDRESS_REGISTER, rTEMPA


### PR DESCRIPTION
Integrate changes from dev branch to fix wrong word size used by address offset template

